### PR TITLE
Add tests for getRandomCards

### DIFF
--- a/__tests__/getRandomCards.test.ts
+++ b/__tests__/getRandomCards.test.ts
@@ -1,0 +1,27 @@
+import { getRandomCards } from "@/app/data/cards";
+
+describe("getRandomCards", () => {
+  it("returns the requested number of unique cards", () => {
+    const cards = getRandomCards(10);
+    const ids = cards.map(card => card.id);
+    const uniqueIds = new Set(ids);
+    expect(cards).toHaveLength(10);
+    expect(uniqueIds.size).toBe(cards.length);
+  });
+
+  it("assigns a boolean isReversed property to each card", () => {
+    const cards = getRandomCards(10);
+    cards.forEach(card => {
+      expect(typeof card.isReversed).toBe("boolean");
+    });
+  });
+
+  it("ensures each card has a defined, non-empty imagePath", () => {
+    const cards = getRandomCards(10);
+    cards.forEach(card => {
+      expect(card.imagePath).toBeDefined();
+      expect(typeof card.imagePath).toBe("string");
+      expect(card.imagePath).not.toBe("");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for getRandomCards to ensure it returns unique cards, boolean flags, and defined images

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d224fb4988331af65a13514b230ed