### PR TITLE
Fix build crash when Supabase env vars missing

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,11 +1,14 @@
 import { createBrowserClient, createServerClient } from '@supabase/ssr'
+import type { SupabaseClient } from '@supabase/supabase-js'
 
 // Supabase client for browser/client-side operations
-export const createBrowserSupabaseClient = () =>
-  createBrowserClient(
+export const createBrowserSupabaseClient = () => {
+  if (typeof window === 'undefined' || !process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) return {} as SupabaseClient
+  return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   )
+}
 
 // Supabase client for server-side operations (API routes, middleware)
 // Note: This should only be called from server components, API routes, or middleware


### PR DESCRIPTION
## Summary
- guard Supabase browser client creation when `window` or env vars are absent

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d226bda3c8331848693b46ec1d9f2