### PR TITLE
Add CI workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+# Workflow name
+name: 'Node.js CI'
+
+# Events for the workflow
+on:
+  pull_request:
+    branches: ['main']
+  push:
+    branches: ['main']
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies and runs `npm test`
- trigger workflow on pushes and pull requests to `main`

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d697c4cf48331aced749527e830f0