### PR TITLE
Implement reduced motion and animation limits

### DIFF
--- a/app/components/CardUtils.tsx
+++ b/app/components/CardUtils.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from "react";
+import { useReducedMotion } from "framer-motion";
 import Image from "next/image";
 import type { TarotCard } from "../data/cards";
 
@@ -20,10 +21,11 @@ export const cardBackStyle = {
 // Reusable hook for generating stars
 export function useStarEffect() {
   const [stars, setStars] = useState<JSX.Element[]>([]);
+  const prefersReducedMotion = useReducedMotion();
   
   useEffect(() => {
     const starElements = [];
-    const numStars = Math.floor(Math.random() * 8) + 5;
+    const numStars = prefersReducedMotion ? 0 : Math.floor(Math.random() * 3) + 2;
     
     for (let i = 0; i < numStars; i++) {
       const size = Math.random() * 3 + 1;

--- a/app/components/MysticalCardDisplay.tsx
+++ b/app/components/MysticalCardDisplay.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import TarotCard from './TarotCard';
 import { cards } from '../data/cards';
 
@@ -17,6 +17,7 @@ export default function MysticalCardDisplay({
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [mounted, setMounted] = useState(false);
   const [stars, setStars] = useState<JSX.Element[]>([]);
+  const prefersReducedMotion = useReducedMotion();
   
   // Get a random selection of cards
   const displayCards = useState(() => {
@@ -36,7 +37,7 @@ export default function MysticalCardDisplay({
     // Generate stars client-side only
     const generateStars = () => {
       const starsArray = [];
-      const numStars = 20;
+      const numStars = prefersReducedMotion ? 0 : 3;
       
       for (let i = 0; i < numStars; i++) {
         const size = Math.random() * 3 + 1;
@@ -163,7 +164,7 @@ export default function MysticalCardDisplay({
               <div
                 className="transform-gpu will-change-transform"
                 style={{
-                  animation: `float ${floatDuration}s ease-in-out infinite alternate`,
+                  animation: prefersReducedMotion ? 'none' : `float ${floatDuration}s ease-in-out infinite alternate`,
                   transform: `translateY(${floatY}px)`,
                 }}
               >

--- a/app/globals.css
+++ b/app/globals.css
@@ -746,3 +746,11 @@ body {
   background: rgba(200, 173, 127, 0.8);
   box-shadow: 0 0 8px rgba(200, 173, 127, 0.4);
 }
+
+/* Respect user motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/docs/SMART_GOALS_TASKS.md
+++ b/docs/SMART_GOALS_TASKS.md
@@ -96,7 +96,7 @@ Each goal follows the SMART criteria:
     - 60fps performance maintained
     - Animation performance audit passed
   - **Dependencies**: TASK-PERF-001
-  - **Status**: Not Started
+  - **Status**: In Progress
 
 - [ ] **TASK-PERF-003**: Add Core Web Vitals monitoring
   - **Priority**: 🔥 High

--- a/progress.md
+++ b/progress.md
@@ -310,6 +310,8 @@ TarotSnap is positioned for immediate growth with:
   - Added Tailwind `container mx-auto` with `max-w-7xl` constraint  
   - Implemented responsive gap controls: `2xl:gap-20` for ultra-wide spacing
   - Updated card sizing: `w-[clamp(160px,18vw,220px)]` for better viewport scaling
-  - Added `2xl:px-0` for optimal ultra-wide padding
-- **Testing:** Verified on 2560x1440 and 3840x2160 resolutions
-- **Result:** Hero content now remains visually connected and centered on all monitor sizes 
+  - Added `2xl:px-0` for optimal ultra-wide padding  - **Testing:** Verified on 2560x1440 and 3840x2160 resolutions
+  - **Result:** Hero content now remains visually connected and centered on all monitor sizes
+
+### July 9, 2025 - Animation Optimization Started
+- **TASK-PERF-002 In Progress** - Reduced star count and disabled float animations when users prefer reduced motion.


### PR DESCRIPTION
## Summary
- support prefers-reduced-motion in styles
- disable floating card animations for reduced motion
- shrink star effects and respect motion setting
- mark TASK-PERF-002 as In Progress and log progress

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7e0ac54c8331bf9b482820877418