### PR TITLE
Add mystical header site-wide

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import StarsBackground, { StarsFallback } from "./components/StarsBackground";
 import { AuthProvider } from "./providers/AuthProvider";
+import { MysticalHeader } from "@/app/components/MysticalHeader";
 import { GoogleAnalytics } from '@next/third-parties/google';
 import StructuredData from "./components/StructuredData";
 
@@ -115,7 +116,8 @@ export default function RootLayout({
         
         {/* Content */}
         <AuthProvider>
-          <main className="relative z-10 min-h-screen">
+          <MysticalHeader />
+          <main className="relative z-10 min-h-screen pt-20">
             {children}
           </main>
         </AuthProvider>


### PR DESCRIPTION
## Summary
- show login/signup header on every page via layout.tsx

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities in unrelated files)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872813ff1e08331abfb101450eee58c