### PR TITLE
Add API route tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ Watch mode:
 npm run test:watch
 ```
 
+The API route tests in `__tests__/api` mock OpenRouter and Supabase so they can
+run offline. Simply run `npm test` after installing dependencies to execute
+them.
+
 ### **Quality Assurance**
 - ✅ Complete browser automation testing with Playwright
 - ✅ End-to-end user journey verification

--- a/__tests__/api/chat-routes.test.ts
+++ b/__tests__/api/chat-routes.test.ts
@@ -1,0 +1,45 @@
+/** @jest-environment node */
+import { NextRequest } from 'next/server'
+
+// Mock Supabase client to simulate unauthenticated user
+jest.mock('@/lib/supabase-server', () => ({
+  createServerSupabaseClient: () => ({
+    auth: {
+      getUser: jest.fn().mockResolvedValue({ data: { user: null } })
+    }
+  })
+}))
+
+function createRequest(method: string) {
+  return new NextRequest('http://localhost/api/test', { method })
+}
+
+describe('Chat API authentication', () => {
+  it('export route requires auth', async () => {
+    const { GET } = require('@/app/api/chat/export/route')
+    const res = await GET(createRequest('GET'))
+    expect(res.status).toBe(401)
+  })
+
+  it('history route requires auth', async () => {
+    const { GET } = require('@/app/api/chat/history/route')
+    const res = await GET(createRequest('GET'))
+    expect(res.status).toBe(401)
+  })
+
+  it('message route requires auth', async () => {
+    const { POST } = require('@/app/api/chat/message/route')
+    const res = await POST(new NextRequest('http://localhost', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ role: 'user', content: 'hi' }) }))
+    expect(res.status).toBe(401)
+  })
+})
+
+// Memory route also checks user
+
+describe('Reading memory API authentication', () => {
+  it('POST requires auth or anon id', async () => {
+    const { POST } = require('@/app/api/reading/memory/route')
+    const res = await POST(new NextRequest('http://localhost', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ action: 'store_session', data: {} }) }))
+    expect(res.status).toBe(401)
+  })
+})

--- a/__tests__/api/reading-route.test.ts
+++ b/__tests__/api/reading-route.test.ts
@@ -1,0 +1,73 @@
+/** @jest-environment node */
+import { NextRequest } from 'next/server'
+
+jest.mock('@/lib/openrouter', () => ({
+  generateTarotReading: jest.fn(async () => ({
+    card: 'The Fool',
+    meaning: 'New beginnings',
+    interpretation: 'interpretation',
+    guidance: 'guidance',
+    energy: 'energy',
+    timeframe: 'timeframe',
+    imagePath: '/image.png'
+  })),
+  generateFollowUpResponse: jest.fn(async () => 'followUp')
+}))
+
+function loadRoute() {
+  jest.resetModules()
+  return require('@/app/api/reading/route')
+}
+
+function createRequest(body: any, ip = '1.1.1.1') {
+  return new NextRequest('http://localhost/api/reading', {
+    method: 'POST',
+    headers: {
+      'x-forwarded-for': ip,
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  })
+}
+
+describe('POST /api/reading', () => {
+  it('returns a tarot reading', async () => {
+    const { POST } = loadRoute()
+    const req = createRequest({ question: 'Will I succeed?' })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.reading.card).toBe('The Fool')
+  })
+
+  it('handles follow-up questions', async () => {
+    const { POST } = loadRoute()
+    const body = {
+      question: 'follow?',
+      followUp: {
+        originalQuestion: 'orig',
+        cardName: 'The Fool',
+        cardMeaning: 'meaning',
+        previousInterpretation: 'interp'
+      }
+    }
+    const req = createRequest(body)
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.type).toBe('followUp')
+    expect(data.response).toBe('followUp')
+  })
+
+  it('enforces daily rate limit', async () => {
+    const { POST } = loadRoute()
+    for (let i = 0; i < 3; i++) {
+      const r = await POST(createRequest({ question: 'Q'+i }))
+      expect(r.status).toBe(200)
+    }
+    const res = await POST(createRequest({ question: 'Limit' }))
+    expect(res.status).toBe(429)
+    const data = await res.json()
+    expect(data.error).toBe('Rate limit exceeded')
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ const customJestConfig = {
   moduleNameMapper: {
     '^@/components/(.*)$': '<rootDir>/app/components/$1',
     '^@/app/(.*)$': '<rootDir>/app/$1',
+    '^@/lib/(.*)$': '<rootDir>/lib/$1'
   }
 };
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -22,27 +22,29 @@ jest.mock('next/image', () => ({
   },
 }));
 
-// Mock intersection observer
-Object.defineProperty(window, 'IntersectionObserver', {
-  writable: true,
-  value: jest.fn().mockImplementation(() => ({
-    observe: jest.fn(),
-    unobserve: jest.fn(),
-    disconnect: jest.fn(),
-  })),
-});
+if (typeof window !== 'undefined') {
+  // Mock intersection observer
+  Object.defineProperty(window, 'IntersectionObserver', {
+    writable: true,
+    value: jest.fn().mockImplementation(() => ({
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+      disconnect: jest.fn(),
+    })),
+  })
 
-// Mock window.matchMedia
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: jest.fn().mockImplementation(query => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-}); 
+  // Mock window.matchMedia
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  })
+}


### PR DESCRIPTION
## Summary
- add Jest tests covering API endpoints
- mock OpenRouter and Supabase interactions
- update Jest config for lib alias and adjust setup script
- document running the new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d6988bf808331b42cad931c1c2b20