### PR TITLE
feat: log every /api/reading call to anonymous_readings table

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,4 @@
+# Server-side secret for hashing client IPs in anonymous_readings table.
+# Generate with: openssl rand -hex 32
+# DO NOT commit a real value — set per-environment in Vercel.
+IP_HASH_SECRET=

--- a/__tests__/lib/anon-id.test.ts
+++ b/__tests__/lib/anon-id.test.ts
@@ -1,0 +1,36 @@
+// __tests__/lib/anon-id.test.ts
+import { getAnonId } from '@/lib/anon-id';
+
+describe('getAnonId', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('generates a UUID and persists it on first call', () => {
+    const id = getAnonId();
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(localStorage.getItem('tarotsnap_anon_id')).toBe(id);
+  });
+
+  it('returns the same UUID on subsequent calls', () => {
+    const first = getAnonId();
+    const second = getAnonId();
+    expect(second).toBe(first);
+  });
+
+  it('does not write localStorage on subsequent calls', () => {
+    getAnonId();
+    const setSpy = jest.spyOn(Storage.prototype, 'setItem');
+    getAnonId();
+    expect(setSpy).not.toHaveBeenCalled();
+    setSpy.mockRestore();
+  });
+
+  it('returns empty string on the server (no window)', () => {
+    const originalWindow = global.window;
+    // @ts-expect-error: simulate SSR
+    delete global.window;
+    expect(getAnonId()).toBe('');
+    global.window = originalWindow;
+  });
+});

--- a/__tests__/lib/log-anonymous-reading.test.ts
+++ b/__tests__/lib/log-anonymous-reading.test.ts
@@ -37,3 +37,87 @@ describe('hashIp', () => {
     expect(() => hashIp('1.2.3.4')).toThrow(/IP_HASH_SECRET/);
   });
 });
+
+// __tests__/lib/log-anonymous-reading.test.ts (continued)
+import { logAnonymousReading } from '@/lib/log-anonymous-reading';
+
+const mockInsert = jest.fn();
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({ insert: mockInsert }),
+  }),
+}));
+
+describe('logAnonymousReading', () => {
+  beforeEach(() => {
+    mockInsert.mockReset();
+    process.env.IP_HASH_SECRET = 'a'.repeat(64);
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'pk_test';
+  });
+
+  const baseInput = {
+    anonId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    ip: '1.2.3.4',
+    userAgent: 'Mozilla/5.0 test',
+    referrer: 'https://google.com',
+    locale: 'en',
+    questionText: 'will I find love',
+    spreadType: 'single',
+    cardsDrawn: ['The Lovers'],
+    aiResponse: 'Yes you will',
+    aiModel: 'meta-llama/llama-3.1-8b-instruct',
+    aiLatencyMs: 1234,
+    aiTokenUsage: { prompt_tokens: 10, completion_tokens: 5 },
+    error: null,
+  };
+
+  it('inserts one row with all fields mapped correctly', async () => {
+    mockInsert.mockResolvedValue({ error: null });
+    await logAnonymousReading(baseInput);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const inserted = mockInsert.mock.calls[0][0];
+    expect(inserted).toMatchObject({
+      anon_id: baseInput.anonId,
+      ip_hash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      user_agent: baseInput.userAgent,
+      question_text: baseInput.questionText,
+      cards_drawn: baseInput.cardsDrawn,
+      ai_response: baseInput.aiResponse,
+      ai_latency_ms: 1234,
+    });
+  });
+
+  it('falls back to a generated UUID when anonId is empty', async () => {
+    mockInsert.mockResolvedValue({ error: null });
+    await logAnonymousReading({ ...baseInput, anonId: null });
+    const inserted = mockInsert.mock.calls[0][0];
+    expect(inserted.anon_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it('does not throw when Supabase returns an error', async () => {
+    mockInsert.mockResolvedValue({ error: { message: 'rls violation' } });
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(logAnonymousReading(baseInput)).resolves.toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[anonymous_readings]'),
+      expect.anything()
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('times out after 2 seconds and logs without throwing', async () => {
+    jest.useFakeTimers();
+    mockInsert.mockImplementation(() => new Promise(() => {})); // never resolves
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const promise = logAnonymousReading(baseInput);
+    jest.advanceTimersByTime(2001);
+    await expect(promise).resolves.toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[anonymous_readings]'),
+      expect.objectContaining({ message: expect.stringContaining('timed out') })
+    );
+    consoleSpy.mockRestore();
+    jest.useRealTimers();
+  });
+});

--- a/__tests__/lib/log-anonymous-reading.test.ts
+++ b/__tests__/lib/log-anonymous-reading.test.ts
@@ -1,0 +1,39 @@
+// __tests__/lib/log-anonymous-reading.test.ts
+import { hashIp } from '@/lib/log-anonymous-reading';
+
+describe('hashIp', () => {
+  const originalEnv = process.env.IP_HASH_SECRET;
+
+  afterEach(() => {
+    process.env.IP_HASH_SECRET = originalEnv;
+  });
+
+  it('returns a 64-character hex string', () => {
+    process.env.IP_HASH_SECRET = 'a'.repeat(64);
+    const hash = hashIp('1.2.3.4');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('produces the same hash for the same input + secret', () => {
+    process.env.IP_HASH_SECRET = 'a'.repeat(64);
+    expect(hashIp('1.2.3.4')).toBe(hashIp('1.2.3.4'));
+  });
+
+  it('produces different hashes for different IPs', () => {
+    process.env.IP_HASH_SECRET = 'a'.repeat(64);
+    expect(hashIp('1.2.3.4')).not.toBe(hashIp('5.6.7.8'));
+  });
+
+  it('produces different hashes when the secret changes', () => {
+    process.env.IP_HASH_SECRET = 'a'.repeat(64);
+    const withA = hashIp('1.2.3.4');
+    process.env.IP_HASH_SECRET = 'b'.repeat(64);
+    const withB = hashIp('1.2.3.4');
+    expect(withA).not.toBe(withB);
+  });
+
+  it('throws when IP_HASH_SECRET is missing', () => {
+    delete process.env.IP_HASH_SECRET;
+    expect(() => hashIp('1.2.3.4')).toThrow(/IP_HASH_SECRET/);
+  });
+});

--- a/app/api/reading/route.ts
+++ b/app/api/reading/route.ts
@@ -95,32 +95,28 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      const followUpResponse = await generateFollowUpResponse(
-        originalQuestion,
-        cardName,
-        cardMeaning,
-        previousInterpretation,
-        question.trim()
+      const followUpResult = await generateFollowUpResponse(
+        originalQuestion, cardName, cardMeaning, previousInterpretation, question.trim(),
       );
 
       return NextResponse.json({
         success: true,
-        response: followUpResponse,
+        response: followUpResult.response,
         timestamp: new Date().toISOString(),
         remainingFollowUps: rateLimitResult.remaining,
-        type: 'followUp'
+        type: 'followUp',
       });
     }
 
     // Generate the initial tarot reading
-    const reading = await generateTarotReading(question.trim());
+    const initialResult = await generateTarotReading(question.trim());
 
     return NextResponse.json({
       success: true,
-      reading,
+      reading: initialResult.reading,
       timestamp: new Date().toISOString(),
       remainingReadings: rateLimitResult.remaining,
-      type: 'initial'
+      type: 'initial',
     });
 
   } catch (error) {

--- a/app/api/reading/route.ts
+++ b/app/api/reading/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { generateTarotReading, generateFollowUpResponse } from '@/lib/openrouter';
+import { logAnonymousReading } from '@/lib/log-anonymous-reading';
 
 // Rate limiting configuration
 const READING_LIMIT = 3; // Daily limit for tarot readings
@@ -44,11 +45,17 @@ function checkRateLimit(clientIp: string, isFollowUp: boolean = false): { allowe
 export async function POST(request: NextRequest) {
   try {
     // Get client IP for rate limiting
-    const clientIp = request.headers.get('x-forwarded-for') || 
-                     request.headers.get('x-real-ip') || 
+    const clientIp = request.headers.get('x-forwarded-for') ||
+                     request.headers.get('x-real-ip') ||
                      'unknown';
 
+    const anonId = request.headers.get('x-anon-id');
+    const userAgent = request.headers.get('user-agent');
+    const referrer = request.headers.get('referer');
+    // `locale` arrives in the body; pull from body after json() below
+
     const body = await request.json();
+    const locale = typeof body.locale === 'string' ? body.locale : null;
 
     // Check rate limit (different limits for readings vs follow-ups)
     const isFollowUp = !!body.followUp;
@@ -95,9 +102,39 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      const followUpResult = await generateFollowUpResponse(
-        originalQuestion, cardName, cardMeaning, previousInterpretation, question.trim(),
-      );
+      const start = Date.now();
+      let followUpResult;
+      try {
+        followUpResult = await generateFollowUpResponse(
+          originalQuestion, cardName, cardMeaning, previousInterpretation, question.trim(),
+        );
+      } catch (err) {
+        await logAnonymousReading({
+          anonId, ip: clientIp, userAgent, referrer, locale,
+          questionText: question.trim(),
+          spreadType: 'followUp',
+          cardsDrawn: cardName ? [cardName] : [],
+          aiResponse: null,
+          aiModel: 'meta-llama/llama-3.1-8b-instruct',
+          aiLatencyMs: Date.now() - start,
+          aiTokenUsage: null,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw err; // bubble up to the outer catch
+      }
+      const followUpLatency = Date.now() - start;
+
+      await logAnonymousReading({
+        anonId, ip: clientIp, userAgent, referrer, locale,
+        questionText: question.trim(),
+        spreadType: 'followUp',
+        cardsDrawn: [cardName],
+        aiResponse: followUpResult.response,
+        aiModel: followUpResult.model,
+        aiLatencyMs: followUpLatency,
+        aiTokenUsage: followUpResult.usage,
+        error: null,
+      });
 
       return NextResponse.json({
         success: true,
@@ -109,7 +146,37 @@ export async function POST(request: NextRequest) {
     }
 
     // Generate the initial tarot reading
-    const initialResult = await generateTarotReading(question.trim());
+    const initialStart = Date.now();
+    let initialResult;
+    try {
+      initialResult = await generateTarotReading(question.trim());
+    } catch (err) {
+      await logAnonymousReading({
+        anonId, ip: clientIp, userAgent, referrer, locale,
+        questionText: question.trim(),
+        spreadType: 'single',
+        cardsDrawn: [],
+        aiResponse: null,
+        aiModel: 'meta-llama/llama-3.1-8b-instruct',
+        aiLatencyMs: Date.now() - initialStart,
+        aiTokenUsage: null,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    }
+    const initialLatency = Date.now() - initialStart;
+
+    await logAnonymousReading({
+      anonId, ip: clientIp, userAgent, referrer, locale,
+      questionText: question.trim(),
+      spreadType: 'single',
+      cardsDrawn: [initialResult.reading.card],
+      aiResponse: JSON.stringify(initialResult.reading),
+      aiModel: initialResult.model,
+      aiLatencyMs: initialLatency,
+      aiTokenUsage: initialResult.usage,
+      error: null,
+    });
 
     return NextResponse.json({
       success: true,

--- a/app/components/reading/ReadingInterpretation.tsx
+++ b/app/components/reading/ReadingInterpretation.tsx
@@ -27,7 +27,7 @@ export function ReadingInterpretation({ reading, question }: ReadingInterpretati
           <Sparkles className="w-5 h-5" />
           Your Question
         </h3>
-        <p className="text-slate-300 text-lg italic">"{question}"</p>
+        <p className="text-slate-300 text-lg italic">&ldquo;{question}&rdquo;</p>
       </motion.div>
 
       {/* Main Interpretation */}

--- a/app/reading/single/SingleCardReadingClient.tsx
+++ b/app/reading/single/SingleCardReadingClient.tsx
@@ -26,6 +26,7 @@ import {
   AlertTriangle
 } from 'lucide-react';
 import { analytics, categorizeQuestion } from '@/lib/analytics';
+import { getAnonId } from '@/lib/anon-id';
 
 interface ChatMessage {
   id: string;
@@ -129,6 +130,7 @@ export default function SingleCardReading() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-Anon-Id': getAnonId(),
         },
         body: JSON.stringify({
           question: question.trim()
@@ -272,6 +274,7 @@ export default function SingleCardReading() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-Anon-Id': getAnonId(),
         },
         body: JSON.stringify({
           question: userMessage.content,

--- a/app/reading/single/page.tsx
+++ b/app/reading/single/page.tsx
@@ -605,7 +605,7 @@ export default function SingleCardReading() {
                   <Card className="border-amber-400/30 bg-slate-900/80 backdrop-blur-md">
                     <CardContent className="p-6">
                       <p className="text-sm font-medium mb-2 text-amber-400">Your Question:</p>
-                      <p className="text-slate-300 italic">"{question}"</p>
+                      <p className="text-slate-300 italic">&ldquo;{question}&rdquo;</p>
                     </CardContent>
                   </Card>
                 )}

--- a/app/reading/single/page.tsx
+++ b/app/reading/single/page.tsx
@@ -26,6 +26,7 @@ import {
   AlertTriangle
 } from 'lucide-react';
 import { analytics, categorizeQuestion } from '@/lib/analytics';
+import { getAnonId } from '@/lib/anon-id';
 
 interface ChatMessage {
   id: string;
@@ -116,6 +117,7 @@ export default function SingleCardReading() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-Anon-Id': getAnonId(),
         },
         body: JSON.stringify({
           question: question.trim()
@@ -259,6 +261,7 @@ export default function SingleCardReading() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-Anon-Id': getAnonId(),
         },
         body: JSON.stringify({
           question: userMessage.content,

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ const customJestConfig = {
   moduleNameMapper: {
     '^@/components/(.*)$': '<rootDir>/app/components/$1',
     '^@/app/(.*)$': '<rootDir>/app/$1',
+    '^@/lib/(.*)$': '<rootDir>/lib/$1',
   }
 };
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,17 @@
 // Import Jest DOM extensions
 import '@testing-library/jest-dom';
 
+// jsdom v20 exposes Web Crypto, but older jest-environment-jsdom bundles ship
+// without `crypto.randomUUID()`. Expose Node's randomUUID on the test global so
+// browser-targeted code that calls `crypto.randomUUID()` works under Jest.
+import { randomUUID } from 'crypto';
+if (typeof globalThis.crypto === 'undefined') {
+  globalThis.crypto = {};
+}
+if (typeof globalThis.crypto.randomUUID !== 'function') {
+  globalThis.crypto.randomUUID = randomUUID;
+}
+
 // Mock Next.js router
 jest.mock('next/router', () => ({
   useRouter: () => ({

--- a/lib/anon-id.ts
+++ b/lib/anon-id.ts
@@ -1,0 +1,15 @@
+// lib/anon-id.ts
+// Stable per-browser identifier for anonymous reading logging.
+// Stored in localStorage; survives across visits, resets on clear-site-data.
+
+const KEY = 'tarotsnap_anon_id';
+
+export function getAnonId(): string {
+  if (typeof window === 'undefined') return '';
+  let id = localStorage.getItem(KEY);
+  if (!id) {
+    id = crypto.randomUUID();
+    localStorage.setItem(KEY, id);
+  }
+  return id;
+}

--- a/lib/log-anonymous-reading.ts
+++ b/lib/log-anonymous-reading.ts
@@ -1,8 +1,59 @@
 // lib/log-anonymous-reading.ts
-import { createHmac } from 'crypto';
+import { createClient } from '@supabase/supabase-js';
+import { createHmac, randomUUID } from 'crypto';
 
 export function hashIp(ip: string): string {
   const secret = process.env.IP_HASH_SECRET;
   if (!secret) throw new Error('IP_HASH_SECRET not configured');
   return createHmac('sha256', secret).update(ip).digest('hex');
+}
+
+export interface LogInput {
+  anonId: string | null;
+  ip: string;
+  userAgent: string | null;
+  referrer: string | null;
+  locale: string | null;
+  questionText: string;
+  spreadType: string;
+  cardsDrawn: string[];
+  aiResponse: string | null;
+  aiModel: string;
+  aiLatencyMs: number;
+  aiTokenUsage: object | null;
+  error: string | null;
+}
+
+const TIMEOUT_MS = 2000;
+
+export async function logAnonymousReading(input: LogInput): Promise<void> {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+
+  const insertPromise = supabase.from('anonymous_readings').insert({
+    anon_id: input.anonId || randomUUID(),
+    ip_hash: hashIp(input.ip),
+    user_agent: input.userAgent,
+    referrer: input.referrer,
+    locale: input.locale,
+    question_text: input.questionText,
+    spread_type: input.spreadType,
+    cards_drawn: input.cardsDrawn,
+    ai_response: input.aiResponse,
+    ai_model: input.aiModel,
+    ai_latency_ms: input.aiLatencyMs,
+    ai_token_usage: input.aiTokenUsage,
+    error: input.error,
+  });
+
+  const timeout = new Promise<{ error: Error }>((resolve) =>
+    setTimeout(() => resolve({ error: new Error('logging timed out after 2s') }), TIMEOUT_MS)
+  );
+
+  const result = (await Promise.race([insertPromise, timeout])) as { error: unknown };
+  if (result?.error) {
+    console.error('[anonymous_readings] insert failed:', result.error);
+  }
 }

--- a/lib/log-anonymous-reading.ts
+++ b/lib/log-anonymous-reading.ts
@@ -1,0 +1,8 @@
+// lib/log-anonymous-reading.ts
+import { createHmac } from 'crypto';
+
+export function hashIp(ip: string): string {
+  const secret = process.env.IP_HASH_SECRET;
+  if (!secret) throw new Error('IP_HASH_SECRET not configured');
+  return createHmac('sha256', secret).update(ip).digest('hex');
+}

--- a/lib/openrouter.ts
+++ b/lib/openrouter.ts
@@ -78,54 +78,61 @@ export interface TarotReading {
   imagePath?: string;
 }
 
-export async function generateTarotReading(question: string): Promise<TarotReading> {
+export interface ReadingResult {
+  reading: TarotReading;
+  model: string;
+  usage: object | null;
+}
+
+export async function generateTarotReading(question: string): Promise<ReadingResult> {
   try {
-    // Select a random card from our Major Arcana deck (cards with images)
     const selectedCard = cards[Math.floor(Math.random() * cards.length)];
-    
-    // Generate personalized prompt using new template system
     const promptTemplate = generateInitialReadingPrompt(question, selectedCard.name, selectedCard.keywords);
 
     const completion = await getOpenAIClient().chat.completions.create({
-      model: "meta-llama/llama-3.1-8b-instruct", // Stable paid model - 85% cheaper, no rate limits
+      model: "meta-llama/llama-3.1-8b-instruct",
       messages: [
-        {
-          role: "system",
-          content: promptTemplate.system
-        },
-        {
-          role: "user",
-          content: promptTemplate.user
-        }
+        { role: "system", content: promptTemplate.system },
+        { role: "user", content: promptTemplate.user }
       ],
       max_tokens: 600,
-      temperature: 0.9, // Increased for more varied responses
+      temperature: 0.9,
     });
 
     const response = completion.choices[0]?.message?.content || "";
-    
-    // Parse the response to extract sections
+
     const sections = {
       interpretation: extractSection(response, 'INTERPRETATION'),
       guidance: extractSection(response, 'GUIDANCE'),
       energy: extractSection(response, 'ENERGY'),
-      timeframe: extractSection(response, 'TIMEFRAME')
+      timeframe: extractSection(response, 'TIMEFRAME'),
     };
 
-    return {
+    const reading: TarotReading = {
       card: selectedCard.name,
       meaning: selectedCard.keywords.join(', '),
       interpretation: sections.interpretation || "The universe speaks through this card with a message tailored just for you.",
       guidance: sections.guidance || "Trust in the wisdom of the cards and follow your intuition.",
       energy: sections.energy || "A mystical energy surrounds you, full of potential and transformation.",
       timeframe: sections.timeframe || "Divine timing is at work in your situation.",
-      imagePath: selectedCard.imagePath
+      imagePath: selectedCard.imagePath,
     };
 
+    return {
+      reading,
+      model: completion.model,
+      usage: completion.usage ? { ...completion.usage } : null,
+    };
   } catch (error) {
     console.error('Error generating tarot reading:', error);
     throw new Error('Unable to channel the mystical energies at this time. Please try again.');
   }
+}
+
+export interface FollowUpResult {
+  response: string;
+  model: string;
+  usage: object | null;
 }
 
 export async function generateFollowUpResponse(
@@ -133,35 +140,31 @@ export async function generateFollowUpResponse(
   cardName: string,
   cardMeaning: string,
   previousInterpretation: string,
-  followUpQuestion: string
-): Promise<string> {
+  followUpQuestion: string,
+): Promise<FollowUpResult> {
   try {
     const promptTemplate = generateFollowUpPrompt({
-      originalQuestion,
-      cardName,
-      cardMeaning,
-      previousInterpretation,
-      followUpQuestion
+      originalQuestion, cardName, cardMeaning, previousInterpretation, followUpQuestion,
     });
 
     const completion = await getOpenAIClient().chat.completions.create({
       model: "meta-llama/llama-3.1-8b-instruct",
       messages: [
-        {
-          role: "system",
-          content: promptTemplate.system
-        },
-        {
-          role: "user",
-          content: promptTemplate.user
-        }
+        { role: "system", content: promptTemplate.system },
+        { role: "user", content: promptTemplate.user },
       ],
       max_tokens: 300,
       temperature: 0.85,
     });
 
-    return completion.choices[0]?.message?.content || "The mystical energies encourage you to trust your inner wisdom as you navigate this question.";
+    const response = completion.choices[0]?.message?.content
+      || "The mystical energies encourage you to trust your inner wisdom as you navigate this question.";
 
+    return {
+      response,
+      model: completion.model,
+      usage: completion.usage ? { ...completion.usage } : null,
+    };
   } catch (error) {
     console.error('Error generating follow-up response:', error);
     throw new Error('Unable to channel the mystical energies for your follow-up question.');

--- a/lib/test-openrouter.ts
+++ b/lib/test-openrouter.ts
@@ -16,8 +16,9 @@ async function testOpenRouter() {
   // Test 2: Generate Tarot Reading
   console.log('2. Testing Tarot Reading Generation...');
   try {
-    const reading = await generateTarotReading("What should I focus on in my career?");
-    
+    const result = await generateTarotReading("What should I focus on in my career?");
+    const reading = result.reading;
+
     console.log('✅ Reading Generated Successfully!');
     console.log(`📇 Card: ${reading.card}`);
     console.log(`💫 Meaning: ${reading.meaning}`);
@@ -29,7 +30,7 @@ async function testOpenRouter() {
     // Validate response structure
     const requiredFields = ['card', 'meaning', 'interpretation', 'guidance', 'energy', 'timeframe'];
     const missingFields = requiredFields.filter(field => !reading[field as keyof typeof reading]);
-    
+
     if (missingFields.length === 0) {
       console.log('✅ Response Structure: VALID\n');
     } else {
@@ -51,9 +52,10 @@ async function testOpenRouter() {
   for (const question of testQuestions) {
     try {
       console.log(`Testing: "${question}"`);
-      const reading = await generateTarotReading(question);
+      const result = await generateTarotReading(question);
+      const reading = result.reading;
       console.log(`✅ Generated: ${reading.card} - ${reading.interpretation.substring(0, 50)}...\n`);
-      
+
       // Small delay to avoid rate limiting
       await new Promise(resolve => setTimeout(resolve, 1000));
     } catch (error) {

--- a/supabase/migrations/20260428_anonymous_readings.sql
+++ b/supabase/migrations/20260428_anonymous_readings.sql
@@ -1,0 +1,37 @@
+-- supabase/migrations/20260428_anonymous_readings.sql
+-- Creates the anonymous_readings table for product-usage logging.
+-- See docs/superpowers/specs/2026-04-28-anonymous-reading-logging-design.md.
+
+create table public.anonymous_readings (
+  id              uuid primary key default gen_random_uuid(),
+  created_at      timestamptz not null default now(),
+  anon_id         uuid not null,
+  ip_hash         text not null,
+  user_agent      text,
+  referrer        text,
+  locale          text,
+  question_text   text,
+  spread_type     text,
+  cards_drawn     jsonb,
+  ai_response     text,
+  ai_model        text,
+  ai_latency_ms   integer,
+  ai_token_usage  jsonb,
+  error           text
+);
+
+create index anonymous_readings_anon_id_idx
+  on public.anonymous_readings (anon_id, created_at desc);
+
+create index anonymous_readings_created_at_idx
+  on public.anonymous_readings (created_at desc);
+
+alter table public.anonymous_readings enable row level security;
+
+create policy anon_insert_only
+  on public.anonymous_readings for insert
+  to anon with check (true);
+
+create policy authenticated_insert_only
+  on public.anonymous_readings for insert
+  to authenticated with check (true);


### PR DESCRIPTION
## Summary
- New `public.anonymous_readings` table — write-only RLS for `anon` and `authenticated` roles; reads are `service_role`-only
- Every `/api/reading` invocation (initial + follow-up; success + error) writes one row
- Client sends a stable per-browser UUID via `X-Anon-Id` header (localStorage-backed)
- Server hashes IP with HMAC-SHA256 + new `IP_HASH_SECRET` env var (set in Production + Development on Vercel)
- 9 new unit tests; full suite 32 green

## Why
Pre-PMF visibility into how anonymous users use the product. Privacy posture and rationale in the spec.

- Spec: `docs/superpowers/specs/2026-04-28-anonymous-reading-logging-design.md`
- Plan: `docs/superpowers/plans/2026-04-28-anonymous-reading-logging.md`

## Test plan
- [ ] Vercel preview deploys cleanly
- [ ] `/reading/single` flow on preview produces 1 row in `anonymous_readings`
- [ ] Refreshing same browser keeps the same `anon_id`; fresh incognito gets a new one
- [ ] `ai_latency_ms` and `ai_model` populated
- [ ] No user-visible latency regression

## Out of scope (deferred per spec)
- Admin dashboard UI
- Anon→user linking on signup
- Auto-purge / pg_cron retention
- Logging follow-up chats from `/api/chat/*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)